### PR TITLE
fix: '.content' -> '.zone-content'

### DIFF
--- a/src/components/EditorWrapper.js
+++ b/src/components/EditorWrapper.js
@@ -100,7 +100,7 @@ export default class EditorWrapper extends React.Component {
     }
 
     return (
-      <div name="EditorWrapper" className="content" ref={(el) => this.wrapper = el}>
+      <div name="EditorWrapper" className="zone-content" ref={(el) => this.wrapper = el}>
         {(buttons) ? buttons : children}
       </div>
     );

--- a/src/components/Zone.js
+++ b/src/components/Zone.js
@@ -272,7 +272,7 @@ export class Zone extends React.Component {
     const zoneHtml = `
       <div class="zone-container" style="display: inline-block; width: ${ zoneWidth }">
         <div class="zone">
-          <div class="content">
+          <div class="zone-content">
             ${html || ''}
           </div>
         </div>


### PR DESCRIPTION
tooltip.css defines styles for `.content` that we don't want to inherit