### PR TITLE
drop-down-menu: reinstate z-index

### DIFF
--- a/src/components/DropDownMenu.js
+++ b/src/components/DropDownMenu.js
@@ -78,7 +78,8 @@ export default class DropDownMenu extends React.Component {
         opacity: 0,
         transition: 'opacity 0.15s ease-out, margin-top 0.2s ease-out',
         pointerEvents: 'none',
-        color: '#666'
+        color: '#666',
+        zIndex: 15
       },
       dropDownMenuOption: {
         cursor: 'pointer',


### PR DESCRIPTION
I accidentally removed this in the last commit while fixing whitespace issues