### PR TITLE
panels: set default z-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "description": "Appcues Editor",
   "main": "lib/bundle.js",
   "scripts": {

--- a/src/helpers/styles/editor.js
+++ b/src/helpers/styles/editor.js
@@ -129,7 +129,8 @@ export const dropdownStyle = {
   animationDuration: '0.15s',
   animationIterationCount: 1,
   animationFillMode: 'both',
-  backgroundColor: '#F7F7F7'
+  backgroundColor: '#F7F7F7',
+  zIndex: 10
 };
 
 export const buttonStyleOptionStyle = {


### PR DESCRIPTION
this prevents dropdown menus from going underneath toolbar icons