### PR TITLE
Fix: Add bold font-color=inherit CSS

### DIFF
--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -60,6 +60,7 @@ export default class RichTextEditor extends React.Component {
 
     return (
       <div className="rich-text" ref={(el) => this.wrapper = el} style={wrapperStyle}>
+        <style>{'.rich-text strong{color: inherit !important;}'}</style>
         { (isEditing) ? (
           (editorState) ? (
             <Editor
@@ -147,7 +148,8 @@ export default class RichTextEditor extends React.Component {
 
     const stylesTag = (styles && styles.length) ? ` style="${styles}"` : '';
 
-    const html = `<div class="rich-text"${stylesTag}><div>${content}</div></div>`;
+    const styleOverride = `<style>.rich-text strong{color:inherit !important;}</style>`;
+    const html = `<div class="rich-text"${stylesTag}>${styleOverride}<div>${content}</div></div>`;
     return html;
   }
 


### PR DESCRIPTION
This fix overrides the gray font color that is on the <strong> element

error (before fix)
![bold-css-error](https://user-images.githubusercontent.com/20328318/30602979-2a205898-9d34-11e7-92d1-20aa94e177b3.gif)
