### PR TITLE
RichText handle pasted HTML

### DIFF
--- a/src/components/DropDownMenu.js
+++ b/src/components/DropDownMenu.js
@@ -83,7 +83,7 @@ export default class DropDownMenu extends React.Component {
         transition: 'opacity 0.15s ease-out, margin-top 0.2s ease-out',
         pointerEvents: 'none',
         color: '#666',
-        zIndex: 15
+        zIndex: 150
       },
       dropDownMenuOption: {
         cursor: 'pointer',

--- a/src/components/Zone.js
+++ b/src/components/Zone.js
@@ -87,7 +87,7 @@ export class Zone extends React.Component {
       display: 'inline-block',
       margin: `0 -${ props.basePadding }px`,
       padding: `0 ${ props.basePadding }px`,
-      width: `calc(100% + ${ props.basePadding * 2 }px - 2px)`,
+      width: `calc(100% + ${ props.basePadding * 2 }px - 1px)`,
       transition: 'background-color 0.15s ease-out, box-shadow 0.15s ease-out, outline-color 0.15s ease-out'
     };
 

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -14,6 +14,7 @@ export default class RichTextEditor extends React.Component {
       EditorState.createWithContent(convertFromHTML(htmlContent), decorator)
       : EditorState.createEmpty(decorator);
     this.handleEditorStateChange(initialEditorState);
+
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -81,7 +81,7 @@ export default class RichTextEditor extends React.Component {
 
     const content = (persistedState.get('content')) || '';
 
-    const wrapperStyle = { zIndex: 2147483647 };
+    const wrapperStyle = { zIndex: 483647 };
     if (marginTop) {
       wrapperStyle.marginTop = marginTop;
     };

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -114,7 +114,6 @@ export default class RichTextEditor extends React.Component {
     if (containsHTML) {
       const newEditorState = EditorState.createWithContent(convertFromPastedHTML(html), decorator);
       const newLocalState = localState.set('editorState', newEditorState)
-      console.log('STUF checking clipboard:', html)
       const newPersistedState = persistedState.set('content', html)
 
       onChange({

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -98,7 +98,7 @@ export default class RichTextEditor extends React.Component {
     return (
       <div className="rich-text"
         ref={(el) => this.wrapper = el}
-        style={{ zIndex: 999999090999009090990909, ...wrapperStyle}}>
+        style={{ zIndex: 2147483647, ...wrapperStyle}}>
         <style>{'.rich-text strong{color: inherit !important;}'}</style>
         { (isEditing) ? (
           (editorState) ? (

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -145,6 +145,8 @@ export default class RichTextEditor extends React.Component {
 
   handlePastedText(text, html, editorState) {
     const { persistedState, localState, onChange } = this.props;
+
+    // Regex search for HTML tags within html clipboard content
     const containsHTML = /<[a-z][\s\S]*>/i.test(html);
 
     if (containsHTML) {
@@ -165,11 +167,8 @@ export default class RichTextEditor extends React.Component {
         html: this.generateHTML(newPersistedState)
       })
       return true;
-
-    } else {
-      return false;
-    }
-
+    } 
+    return false
   }
 
   handleEditorStateChange(editorState) {

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -81,7 +81,7 @@ export default class RichTextEditor extends React.Component {
 
     const content = (persistedState.get('content')) || '';
 
-    const wrapperStyle = {};
+    const wrapperStyle = { zIndex: 2147483647 };
     if (marginTop) {
       wrapperStyle.marginTop = marginTop;
     };
@@ -98,7 +98,7 @@ export default class RichTextEditor extends React.Component {
     return (
       <div className="rich-text"
         ref={(el) => this.wrapper = el}
-        style={{ zIndex: 2147483647, ...wrapperStyle}}>
+        style={wrapperStyle}>
         <style>{'.rich-text strong{color: inherit !important;}'}</style>
         { (isEditing) ? (
           (editorState) ? (

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { Editor, EditorState, RichUtils, ContentState, Modifier } from 'draft-js';
-import { decorator, convertFromHTML, convertFromPastedHTML,  convertToHTML, customStyleFn, blockStyleFn } from '../../helpers/draft/convert';
+import { Editor, EditorState, RichUtils } from 'draft-js';
+import { decorator, convertFromHTML, convertFromPastedHTML, convertToHTML, customStyleFn, blockStyleFn } from '../../helpers/draft/convert';
 import { placeholderStyle } from '../../helpers/styles/editor';
 
 export default class RichTextEditor extends React.Component {
@@ -59,7 +59,7 @@ export default class RichTextEditor extends React.Component {
     if (marginLeft) {
       wrapperStyle.marginLeft = marginLeft;
     };
-//
+
     return (
       <div className="rich-text" ref={(el) => this.wrapper = el} style={wrapperStyle}>
         { (isEditing) ? (

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -105,12 +105,18 @@ export default class RichTextEditor extends React.Component {
 
   handlePastedText(text, html, editorState) {
     const { persistedState, localState } = this.props;
-    console.log('STUF text?', html)
-    const newEditorState = EditorState.createWithContent(convertFromHTML(html), decorator)
-    this.handleEditorStateChange(newEditorState);
-    
-    // this.onChange(EditorState.push(editorState, newState, 'insert-fragment'));
-    return true;
+    const containsHTML = /<[a-z][\s\S]*>/i.test(html);
+    console.log('STUF contains HTML?', containsHTML);
+
+    if (containsHTML) {
+      const newEditorState = EditorState.createWithContent(convertFromHTML(html), decorator)
+      this.handleEditorStateChange(newEditorState);
+      
+      // this.onChange(EditorState.push(editorState, newState, 'insert-fragment'));
+      return true;
+    } else {
+      return false;
+    }
 
   }
 

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -112,7 +112,7 @@ export default class RichTextEditor extends React.Component {
     if (containsHTML) {
       const newEditorState = EditorState.createWithContent(convertFromPastedHTML(html), decorator);
       const newLocalState = localState.set('editorState', newEditorState)
-
+      console.log('STUF checking clipboard:', html)
       const newPersistedState = persistedState.set('content', html)
 
       onChange({

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -59,7 +59,7 @@ export default class RichTextEditor extends React.Component {
     if (marginLeft) {
       wrapperStyle.marginLeft = marginLeft;
     };
-
+//
     return (
       <div className="rich-text" ref={(el) => this.wrapper = el} style={wrapperStyle}>
         { (isEditing) ? (
@@ -110,7 +110,6 @@ export default class RichTextEditor extends React.Component {
     const containsHTML = /<[a-z][\s\S]*>/i.test(html);
 
     if (containsHTML) {
-      console.log('STUFF CLIPBOARD', html)
       const newEditorState = EditorState.createWithContent(convertFromPastedHTML(html), decorator);
       const newLocalState = localState.set('editorState', newEditorState)
 
@@ -121,7 +120,6 @@ export default class RichTextEditor extends React.Component {
         localState: newLocalState,
         html: this.generateHTML(newPersistedState)
       })
-
       return true;
 
     } else {

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { Editor, EditorState, RichUtils } from 'draft-js';
+import { Editor, EditorState, RichUtils, Modifier } from 'draft-js';
 import { decorator, convertFromHTML, convertFromPastedHTML, convertToHTML, customStyleFn, blockStyleFn, getResetSelection } from '../../helpers/draft/convert';
 import { placeholderStyle } from '../../helpers/styles/editor';
 
@@ -148,7 +148,14 @@ export default class RichTextEditor extends React.Component {
     const containsHTML = /<[a-z][\s\S]*>/i.test(html);
 
     if (containsHTML) {
-      const newEditorState = EditorState.createWithContent(convertFromPastedHTML(html), decorator);
+      const newContent = convertFromPastedHTML(html).getBlockMap();
+      const newContentState = Modifier.replaceWithFragment(
+        editorState.getCurrentContent(),
+        editorState.getSelection(),
+        newContent
+      );
+
+      const newEditorState = EditorState.push(editorState, newContentState);
       const newLocalState = localState.set('editorState', newEditorState)
       const newPersistedState = persistedState.set('content', html)
 

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { Editor, EditorState, RichUtils } from 'draft-js';
+import { Editor, EditorState, RichUtils, ContentState, Modifier } from 'draft-js';
 import { decorator, convertFromHTML, convertToHTML, customStyleFn, blockStyleFn } from '../../helpers/draft/convert';
 import { placeholderStyle } from '../../helpers/styles/editor';
 
@@ -77,6 +77,7 @@ export default class RichTextEditor extends React.Component {
                   return 'not-handled';
                 }
               }
+              handlePastedText={(text, html, editorState) => this.handlePastedText(text, html, editorState)}
               onChange={(editorState) => this.handleEditorStateChange(editorState)}
             />
           ) : null
@@ -100,6 +101,17 @@ export default class RichTextEditor extends React.Component {
     if (this.editor) {
       this.editor.focus();
     }
+  }
+
+  handlePastedText(text, html, editorState) {
+    const { persistedState, localState } = this.props;
+    console.log('STUF text?', html)
+    const newEditorState = EditorState.createWithContent(convertFromHTML(html), decorator)
+    this.handleEditorStateChange(newEditorState);
+    
+    // this.onChange(EditorState.push(editorState, newState, 'insert-fragment'));
+    return true;
+
   }
 
   handleEditorStateChange(editorState) {

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -109,7 +109,7 @@ export default class RichTextEditor extends React.Component {
     const containsHTML = /<[a-z][\s\S]*>/i.test(html);
 
     if (containsHTML) {
-
+      console.log('STUFF CLIPBOARD', html)
       const newEditorState = EditorState.createWithContent(convertFromPastedHTML(html), decorator);
       const newLocalState = localState.set('editorState', newEditorState)
 
@@ -122,6 +122,7 @@ export default class RichTextEditor extends React.Component {
       })
 
       return true;
+
     } else {
       return false;
     }

--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -61,7 +61,9 @@ export default class RichTextEditor extends React.Component {
     };
 
     return (
-      <div className="rich-text" ref={(el) => this.wrapper = el} style={wrapperStyle}>
+      <div className="rich-text"
+        ref={(el) => this.wrapper = el}
+        style={{ zIndex: 999999090999009090990909, ...wrapperStyle}}>
         { (isEditing) ? (
           (editorState) ? (
             <Editor

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -14,6 +14,7 @@ export function convertFromHTML(htmlContent) {
   return draftConvertFromHTML({
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (nodeName === 'span' && node.style && node.style.color) {
+        console.log('STUF node style color?', nodeName, node.style.color)
         return currentStyle.add(`${CUSTOM_STYLE_PREFIX_COLOR}${node.style.color}`);
       } else {
         return currentStyle;
@@ -47,6 +48,8 @@ export function convertFromHTML(htmlContent) {
       }
 
       if (node.style && node.style.textAlign) {
+        // console.log('STUF htmltoblock', node)
+        // console.log('STUF node children?', node.childNodes)
         return {
           type: nodeType,
           data: {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -20,6 +20,7 @@ export function convertFromPastedHTML(htmlContent) {
       }
     },
     htmlToEntity: (nodeName, node) => {
+      console.log('Stuf ENTITY?', node)
       const entity = linkToEntity(nodeName, node);
       return entity;
     },

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -16,9 +16,8 @@ export function convertFromHTML(htmlContent) {
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (nodeName === 'span' && node.style && node.style.color) {
         return currentStyle.add(`${CUSTOM_STYLE_PREFIX_COLOR}${node.style.color}`);
-      } else {
-        return currentStyle;
       }
+      return currentStyle;
     },
     htmlToEntity: (nodeName, node) => {
       const entity = linkToEntity(nodeName, node);
@@ -64,9 +63,8 @@ export function convertFromPastedHTML(htmlContent) {
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (nodeName === 'span' && node.style && node.style.color && node.style.color !== 'inherit') {
         return currentStyle.add(`${CUSTOM_STYLE_PREFIX_COLOR}${node.style.color}`);
-      } else {
-        return currentStyle;
       }
+      return currentStyle;
     },
     htmlToEntity: (nodeName, node) => {
       const entity = linkToEntity(nodeName, node);
@@ -78,7 +76,7 @@ export function convertFromPastedHTML(htmlContent) {
       if (node.children.length < 1  && isBlank) return;
 
       // Don't convert table elements
-      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') return;
+      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') return false;
 
       let nodeType = 'unstyled';
       switch(nodeName) {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -1,8 +1,7 @@
 /* eslint react/display-name: 0 */  // Not exporting React components here
 import React from 'react';
-import { Map } from 'immutable';
 import { convertToHTML as draftConvertToHTML, convertFromHTML as draftConvertFromHTML } from 'draft-convert';
-import { LinkDecorator, linkToEntity, entityToLink, textToEntity } from '../../helpers/draft/LinkDecorator';
+import { LinkDecorator, linkToEntity, entityToLink } from '../../helpers/draft/LinkDecorator';
 import { CompositeDecorator } from 'draft-js';
 
 export const CUSTOM_STYLE_PREFIX_COLOR = 'COLOR_';
@@ -95,6 +94,8 @@ export function convertFromPastedHTML(htmlContent) {
         case 'h5':
           nodeType = 'header-five';
           break;
+        case 'img':
+          nodeType = 'image';
         case 'br':
           return;
       }
@@ -149,6 +150,8 @@ export function convertToHTML(editorState) {
             return <h4 {...styleProps} />;
           case 'header-five':
             return <h5 {...styleProps} />;
+          case 'image':
+            return <img {...styleProps} />;
           default:
             return <p {...styleProps} />;
         }
@@ -164,6 +167,16 @@ export function convertToHTML(editorState) {
 export function customStyleFn(style) {
   const styleNames = style.toJS();
   return styleNames.reduce((styles, styleName) => {
+    if (styleName === 'CODE') {
+      styles.color = '#c7254e';
+      styles.padding = '2px 4px';
+      styles.fontSize = '90%';
+      styles.backgroundColor = 'rgba(249,242,244,0.7)';
+      styles.borderRadius = '4px';
+    }
+    if (styleName === 'CODE' || styleName === 'PRE') {
+      styles.fontFamily = 'Menlo,Monaco,Consolas,"Courier New",monospace';
+    }
     if(styleName.startsWith(CUSTOM_STYLE_PREFIX_COLOR)) {
       styles.color = styleName.split(CUSTOM_STYLE_PREFIX_COLOR)[1];
     }
@@ -173,9 +186,7 @@ export function customStyleFn(style) {
 
 export function blockStyleFn(contentBlock) {
   const { textAlign } = contentBlock.getData().toJS();
-
   if (textAlign) {
     return `align-${textAlign}`;
   }
-  
 }

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -72,9 +72,7 @@ export function convertFromPastedHTML(htmlContent) {
       const entity = linkToEntity(nodeName, node);
       return entity;
     },
-    textToEntity: () => {
-      return [];
-    },
+    
     htmlToBlock: (nodeName, node) => {
 
       // Don't convert table elements

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -109,7 +109,7 @@ export function convertFromPastedHTML(htmlContent) {
         }
       }
 
-      const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol';
+      const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol' && nodeName !== 'blockquote';
 
       if (node.style && node.style.textAlign && isNotNestedBlock) {        
         return {
@@ -163,6 +163,7 @@ export function convertToHTML(editorState) {
 export function customStyleFn(style) {
   const styleNames = style.toJS();
   return styleNames.reduce((styles, styleName) => {
+    console.log('STUF checking styles', styles, styleName)
     if (styleName === 'CODE') {
       styles.color = '#c7254e';
       styles.padding = '2px 4px';

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -45,16 +45,22 @@ export function convertFromPastedHTML(htmlContent) {
           nodeType = 'header-five';
           break;
       }
-      console.log('STUFF checking node', node)
-      console.log('STUFF node children', node.childNodes)
-      if (node.style && node.style.textAlign) {
-        return {
-          type: nodeType,
-          data: {
-            textAlign: node.style.textAlign
-          }
-        };
+      if (node.childNodes.length === 1 && node.childNodes[0].nodeName === '#text') {
+
+        const textContent = node.childNodes[0].textContent;
+        const isBlank = /^\s+$/.test(textContent);
+
+        // Don't convert elements that contain all whitespace content
+        if (node.style && node.style.textAlign && !isBlank) {
+          return {
+            type: nodeType,
+            data: {
+              textAlign: node.style.textAlign
+            }
+          };
+        }
       }
+
     }
   })(htmlContent);
 }

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -94,8 +94,6 @@ export function convertFromPastedHTML(htmlContent) {
         case 'h5':
           nodeType = 'header-five';
           break;
-        case 'img':
-          nodeType = 'image';
         case 'br':
           return;
       }
@@ -111,7 +109,7 @@ export function convertFromPastedHTML(htmlContent) {
         }
       }
 
-      const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol' && nodeName !== 'pre';
+      const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol';
 
       if (node.style && node.style.textAlign && isNotNestedBlock) {        
         return {
@@ -150,8 +148,6 @@ export function convertToHTML(editorState) {
             return <h4 {...styleProps} />;
           case 'header-five':
             return <h5 {...styleProps} />;
-          case 'image':
-            return <img {...styleProps} />;
           default:
             return <p {...styleProps} />;
         }

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -71,12 +71,17 @@ export function convertFromPastedHTML(htmlContent) {
     htmlToEntity: (nodeName, node) => {
       const entity = linkToEntity(nodeName, node);
       return entity;
-      
     },
     textToEntity: () => {
       return [];
     },
     htmlToBlock: (nodeName, node) => {
+
+      // Don't convert table elements
+      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') {
+        return;
+      }
+
       let nodeType = 'unstyled';
       switch(nodeName) {
         case 'h1':
@@ -99,7 +104,6 @@ export function convertFromPastedHTML(htmlContent) {
       }
 
       if (node.children.length < 1) {
-
         const textContent = node.innerText;
         const isBlank = /^\s+$/.test(textContent);
 
@@ -111,7 +115,7 @@ export function convertFromPastedHTML(htmlContent) {
 
       const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol' && nodeName !== 'blockquote';
 
-      if (node.style && node.style.textAlign && isNotNestedBlock) {        
+      if (node.style && node.style.textAlign && isNotNestedBlock) {
         return {
           type: nodeType,
           data: {
@@ -163,7 +167,6 @@ export function convertToHTML(editorState) {
 export function customStyleFn(style) {
   const styleNames = style.toJS();
   return styleNames.reduce((styles, styleName) => {
-    console.log('STUF checking styles', styles, styleName)
     if (styleName === 'CODE') {
       styles.color = '#c7254e';
       styles.padding = '2px 4px';

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -10,11 +10,59 @@ export const decorator = new CompositeDecorator([
   LinkDecorator
 ]);
 
+export function convertFromPastedHTML(htmlContent) {
+  return draftConvertFromHTML({
+    htmlToStyle: (nodeName, node, currentStyle) => {
+      if (nodeName === 'span' && node.style && node.style.color) {
+        return currentStyle.add(`${CUSTOM_STYLE_PREFIX_COLOR}${node.style.color}`);
+      } else {
+        return currentStyle;
+      }
+    },
+    htmlToEntity: (nodeName, node) => {
+      const entity = linkToEntity(nodeName, node);
+      return entity;
+    },
+    textToEntity: () => {
+      return [];
+    },
+    htmlToBlock: (nodeName, node) => {
+      let nodeType = 'unstyled';
+      switch(nodeName) {
+        case 'h1':
+          nodeType = 'header-one';
+          break;
+        case 'h2':
+          nodeType = 'header-two';
+          break;
+        case 'h3':
+          nodeType = 'header-three';
+          break;
+        case 'h4':
+          nodeType = 'header-four';
+          break;
+        case 'h5':
+          nodeType = 'header-five';
+          break;
+      }
+      console.log('STUFF checking node', node)
+      console.log('STUFF node children', node.childNodes)
+      if (node.style && node.style.textAlign) {
+        return {
+          type: nodeType,
+          data: {
+            textAlign: node.style.textAlign
+          }
+        };
+      }
+    }
+  })(htmlContent);
+}
+
 export function convertFromHTML(htmlContent) {
   return draftConvertFromHTML({
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (nodeName === 'span' && node.style && node.style.color) {
-        console.log('STUF node style color?', nodeName, node.style.color)
         return currentStyle.add(`${CUSTOM_STYLE_PREFIX_COLOR}${node.style.color}`);
       } else {
         return currentStyle;
@@ -48,8 +96,6 @@ export function convertFromHTML(htmlContent) {
       }
 
       if (node.style && node.style.textAlign) {
-        // console.log('STUF htmltoblock', node)
-        // console.log('STUF node children?', node.childNodes)
         return {
           type: nodeType,
           data: {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -95,6 +95,8 @@ export function convertFromPastedHTML(htmlContent) {
         case 'h5':
           nodeType = 'header-five';
           break;
+        case 'br':
+          return;
       }
 
       if (node.children.length < 1) {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -76,7 +76,7 @@ export function convertFromPastedHTML(htmlContent) {
       if (node.children.length < 1  && isBlank) return;
 
       // Don't convert table elements
-      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') return false;
+      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') return;
 
       let nodeType = 'unstyled';
       switch(nodeName) {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -72,8 +72,10 @@ export function convertFromPastedHTML(htmlContent) {
       const entity = linkToEntity(nodeName, node);
       return entity;
     },
-    
     htmlToBlock: (nodeName, node) => {
+      const textContent = node.innerText;
+      const isBlank = /^\s+$/.test(textContent);
+      if (node.children.length < 1  && isBlank) return;
 
       // Don't convert table elements
       if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') {
@@ -99,16 +101,6 @@ export function convertFromPastedHTML(htmlContent) {
           break;
         case 'br':
           return;
-      }
-
-      if (node.children.length < 1) {
-        const textContent = node.innerText;
-        const isBlank = /^\s+$/.test(textContent);
-
-        // Don't convert elements that contain only whitespace content
-        if (isBlank) {
-          return;
-        }
       }
 
       const isNotNestedBlock = nodeName !== 'ul' && nodeName !== 'ol' && nodeName !== 'blockquote';

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -78,9 +78,7 @@ export function convertFromPastedHTML(htmlContent) {
       if (node.children.length < 1  && isBlank) return;
 
       // Don't convert table elements
-      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') {
-        return;
-      }
+      if (nodeName === 'table' || nodeName === 'tr' || nodeName === 'td' || nodeName === 'tbody') return;
 
       let nodeType = 'unstyled';
       switch(nodeName) {


### PR DESCRIPTION
Added a paste handler to Editor component to extend Draft's ability to convert HTML. Changes include:
- Handling nested elements (ul, ol, blockquote)
- Retaining text-alignment and color styles when pasting from copied Appcues content
- Better way to handle table elements