### PR TITLE
Hotfix: Prevent blurring when clicking toolbar element

### DIFF
--- a/src/editors/richtext/RichTextEditor.js
+++ b/src/editors/richtext/RichTextEditor.js
@@ -36,9 +36,10 @@ export default class RichTextEditor extends React.Component {
 
       // If mouseUp happened over a Toolbar element,
       // don't reset editor focus.
-      const hasToolbarElement = document.getElementById('appcues-host').shadowRoot.firstChild.getElementsByClassName('resolved')[0].shadowRoot.firstChild.querySelectorAll('[name="EditorWrapperEditingToolbar"]').length;
+      const toolbarElement = document.getElementById('appcues-host').shadowRoot.firstChild.getElementsByClassName('resolved')[0].shadowRoot.firstChild.querySelectorAll('[name="EditorWrapperEditingToolbar"]');
+      const hasToolbarElement = toolbarElement && toolbarElement.length;
 
-      if (hasToolbarElement) {
+      if (hasToolbarElement && ReactDOM.findDOMNode(toolbarElement[0]).contains(e.path[0])) {
         return;
       }
 


### PR DESCRIPTION
- Use ReactDOM.findNode to detect mouse event over toolbar element