### PR TITLE
Fix: Remove hyperlink protocol

### DIFF
--- a/src/editor-actions/ButtonAction.js
+++ b/src/editor-actions/ButtonAction.js
@@ -236,7 +236,7 @@ export default class ButtonAction extends React.Component {
     if (buttonActionType == BUTTON_ACTION_TYPES.URL) {
       return persistedState
         .set('buttonActionType', buttonActionType)
-        .set('href', state.hrefWithProtocol)
+        .set('href', state.href)
         .set('isNewWindow', state.isNewWindow)
         .delete('stepIndex')
         .delete('flowId');
@@ -258,9 +258,7 @@ export default class ButtonAction extends React.Component {
     const { localState, persistedState, onChange, onToggleActive } = this.props;
     const { isMenuOpen, isNewWindow, href, buttonActionType, flowId } = this.state;
 
-    const hrefWithProtocol = (href.includes('://') || href.includes('//')) ? href : '//' + href;
-
-    const newPersistedState = this.getPersistedStateByButtonActionType(buttonActionType, persistedState, { hrefWithProtocol, isNewWindow, flowId });
+    const newPersistedState = this.getPersistedStateByButtonActionType(buttonActionType, persistedState, { href, isNewWindow, flowId });
 
     this.setState({
       isMenuOpen: !isMenuOpen

--- a/src/editor-actions/Hyperlink.js
+++ b/src/editor-actions/Hyperlink.js
@@ -129,9 +129,7 @@ export default class Hyperlink extends React.Component {
 
     setTimeout(() => onToggleActive(false), 200);
 
-    const hrefWithProtocol = (href.includes('://')) ? href : '//' + href;
-
-    onChange(hrefWithProtocol, isNewWindow);
+    onChange(href, isNewWindow);
   }
 
 }

--- a/src/editor-actions/ImageOnClick.js
+++ b/src/editor-actions/ImageOnClick.js
@@ -170,12 +170,10 @@ export default class ImageOnClick extends React.Component {
     const { persistedState } = this.props;
     const { flowId, href, isNewWindow } = this.state;
 
-    const hrefWithProtocol = (href.includes('://') || href.includes('//')) ? href : '//' + href;
-
     switch (currentActionType) {
       case IMG_ACTION_TYPES.GO_TO_URL:
         return persistedState
-          .set('href', (href && hrefWithProtocol))
+          .set('href', href)
           .set('isNewWindow', isNewWindow)
           .delete('flowId');
       case IMG_ACTION_TYPES.SHOW_APPCUES_FLOW:

--- a/src/helpers/draft/LinkDecorator.js
+++ b/src/helpers/draft/LinkDecorator.js
@@ -44,7 +44,7 @@ export function linkToEntity(nodeName, node) {
   if (nodeName === 'a') {
 
     // We want to pull the literal href value provided by users.
-    const href = node.attributes.getNamedItem('href').value;
+    const href = node.getAttribute('href');
 
     return Entity.create(
       'LINK',

--- a/src/helpers/draft/LinkDecorator.js
+++ b/src/helpers/draft/LinkDecorator.js
@@ -42,11 +42,15 @@ export const LinkDecorator = {
 
 export function linkToEntity(nodeName, node) {
   if (nodeName === 'a') {
+
+    // We want to pull the literal href value provided by users.
+    const href = node.attributes.getNamedItem('href').value;
+
     return Entity.create(
       'LINK',
       'MUTABLE',
       {
-        href: node.href,
+        href: href,
         color: node.style.color || node.parentNode.style.color,
         isNewWindow: (node.target === '_blank') ? true : false
       }


### PR DESCRIPTION
Do not append protocol to user-provided href values and pull literal href values from link entity inside LinkDecorator.