### PR TITLE
hotfix: apply zone styles to all components on save

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -299,7 +299,17 @@ export class Canvas extends React.Component {
       if (zones && zones.size) {
         zoneBlocks = zones.map(zone => {
           const zoneId = zone.get('id');
-          return zonesWithHtml.has(zoneId) ? zonesWithHtml.get(zoneId).get('html') : "";
+          const zoneHTML = zonesWithHtml.has(zoneId) ? zonesWithHtml.get(zoneId).get('html') : "";
+          const zoneWidth = `${ 100 / (zones.size|| 1) }%`;
+          return `
+            <div class="zone-container" style="display: inline-block; width: ${ zoneWidth }">
+              <div class="zone">
+                <div class="zone-content">
+                  ${zoneHTML}
+                </div>
+              </div>
+            </div>
+          `;
         });
       }
       html += `

--- a/src/components/Zone.js
+++ b/src/components/Zone.js
@@ -303,21 +303,9 @@ export class Zone extends React.Component {
       html = this.activeEditor.generateHTML(persistedState);
     }
 
-    const zoneWidth = `${ 100 / row.get('zones').size }%`;
-
-    const zoneHtml = `
-      <div class="zone-container" style="display: inline-block; width: ${ zoneWidth }">
-        <div class="zone">
-          <div class="zone-content">
-            ${html || ''}
-          </div>
-        </div>
-      </div>
-    `;
-
     const updatedZone = zone.set('persistedState', persistedState);
 
-    dispatch(zoneActions.updateZoneHtml(zone.get('id'), zoneHtml));
+    dispatch(zoneActions.updateZoneHtml(zone.get('id'), html));
     dispatch(editorActions.updateZone(row, updatedZone));
   }
 


### PR DESCRIPTION
Currently, Multi-zone rows don't work because we only apply the "zone-container" class to the most recently edited zones in a row (causing rows to lose styling when another row is edited). This fixes that so we always apply the appropriate classes and widths to each zone 
![screen shot 2017-11-13 at 3 28 10 pm](https://user-images.githubusercontent.com/6528140/32747651-6d607c90-c887-11e7-9e6b-f55ffe8150c1.png)
