### PR TITLE
Buttons: Use data-step="end-flow" for Appcues trigger button

### DIFF
--- a/src/editors/button/ButtonEditor.js
+++ b/src/editors/button/ButtonEditor.js
@@ -177,7 +177,7 @@ export default class ButtonEditor extends React.Component {
         break;
       case BUTTON_ACTION_TYPES.APPCUES:
         buttonAttrs['onclick'] = `window.parent.Appcues.show('${ flowId }')`;
-        buttonAttrs['data-step'] = BUTTON_ACTION_TYPES.NEXT_GROUP;
+        buttonAttrs['data-step'] = BUTTON_ACTION_TYPES.END_STEP_AND_FLOW;
         break;
       default:
         buttonAttrs['data-step'] = BUTTON_ACTION_TYPES.NEXT_PAGE;

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -54,6 +54,7 @@ export const BUTTON_ACTION_TYPES = {
   CUSTOM_PAGE: 'custom',
   END_FLOW: 'skip',
   NEXT_GROUP: 'end',
+  END_STEP_AND_FLOW: 'end-flow',
   APPCUES: 'appcues'
 };
 


### PR DESCRIPTION
Data-step="end" only ends the step group, so if there is a subsequent step group, that group will flash briefly before the new Appcues flow will show. Solution: Use new data-step value which will end the current step group as well as the flow.