### PR TITLE
invalid-HTML: fix invalid HTML created when using a boolean attribute in a tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "draft-convert": "github:appcues/draft-convert",
     "draft-js": "github:appcues/draft-js",
     "emoji-mart": "^1.0.1",
-    "html-parse-stringify2": "^1.2.1",
+    "html-parse-stringify2": "^2.0.1",
     "immutable": "^3.8.1",
     "node-object-hash": "^1.2.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
Was turning `<input autofocus type="text"/>` into `<input autofocus="type" text=""/>`.

This happened often when using Wistia embed codes (or any embed code).

I was going to yell at @rayd in `rayd/html-parse-stringify2` for this but he already fixed it.