### PR TITLE
Hotfix: Add multiple radio forms, fix placeholder text

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -180,16 +180,22 @@ export class Canvas extends React.Component {
       <style>
         {
           `
+          .DraftEditor-root {
+            position: relative;
+          }
+
           .public-DraftEditorPlaceholder-root {
             position: absolute;
             z-index: 0;
+            top: 0;
+            opacity: 0.8;
+            transition: opacity 0.15s ease-out;
           }
 
-
-
-          .DraftEditorPlaceholder-hidden {
-            display: none;
+          .public-DraftEditorPlaceholder-hasFocus {
+            opacity: 0.5;
           }
+
           `
         }
       </style>

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -167,10 +167,32 @@ export class Canvas extends React.Component {
         style={ style }
         ref={ (el) => this.wrapper = el }>
         { this.renderKeyframeStyles() }
+        { this.renderDraftJSStyles() }
         { rowNodes }
         { fullScreenAddNode }
         { addButtonNode }
       </div>
+    );
+  }
+
+  renderDraftJSStyles() {
+    return(
+      <style>
+        {
+          `
+          .public-DraftEditorPlaceholder-root {
+            position: absolute;
+            z-index: 0;
+          }
+
+
+
+          .DraftEditorPlaceholder-hidden {
+            display: none;
+          }
+          `
+        }
+      </style>
     );
   }
 

--- a/src/components/EditorSelector.js
+++ b/src/components/EditorSelector.js
@@ -79,18 +79,7 @@ const editors = {
     Button: FormRadioButton,
     text: 'Radio Select',
     type: 'SelectionField',
-    category: 'Forms',
-    rows: fromJS([
-      {
-        id: uuid(),
-        zones: [
-          {
-            id: uuid(),
-            type: 'SelectionField'
-          }
-        ]
-      }
-    ])
+    category: 'Forms'
   },
   [EDITOR_TYPES.RATING]: {
     Button: FormRatingButton,

--- a/src/editors/form-select/SelectionEditor.js
+++ b/src/editors/form-select/SelectionEditor.js
@@ -77,7 +77,6 @@ export default class SelectionEditor extends React.Component {
       wrapperStyle.marginLeft = marginLeft;
     };
 
-    console.log('optionz', options);
     return (
       <div>
         <style> {`

--- a/src/editors/form-select/SelectionEditor.js
+++ b/src/editors/form-select/SelectionEditor.js
@@ -136,7 +136,7 @@ export default class SelectionEditor extends React.Component {
             </div>
           </form>
         ) : (
-          (options.length || label) ? (
+          (options.size > 0 || label) ? (
             <form className="step-action-form" style={wrapperStyle}>
               <div className="fields">
                 <div data-field-id={ zone.get('id') } className="field">
@@ -152,13 +152,13 @@ export default class SelectionEditor extends React.Component {
               </div>
             </form>
           ) : (
-            <div style={ placeholderStyle }>Click to add your options</div>          
+            <div style={ placeholderStyle }>Click to add your options</div>
           )
         )}
       </div>
     );
   }
-  
+
   // Instance Method
   focus() {
   }
@@ -299,7 +299,7 @@ export default class SelectionEditor extends React.Component {
                           }]
                         }
                       ]
-                    }, 
+                    },
                     {
                       type: 'tag',
                       name: 'div',

--- a/src/editors/form-select/SelectionEditor.js
+++ b/src/editors/form-select/SelectionEditor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import HTMLParser from 'html-parse-stringify2';
 import { Editor, EditorState, ContentState } from 'draft-js';
 
@@ -39,7 +39,7 @@ export default class SelectionEditor extends React.Component {
     const editorState = localState.get('editorState');
 
     const label = persistedState.get('label');
-    const options = persistedState.get('options') || [];
+    const options = persistedState.get('options') || List();
     const optionString = (localState.get('options')) || options.join('\n') || '';
     const isRequired = persistedState.get('isRequired') || false;
 
@@ -77,6 +77,7 @@ export default class SelectionEditor extends React.Component {
       wrapperStyle.marginLeft = marginLeft;
     };
 
+    console.log('optionz', options);
     return (
       <div>
         <style> {`
@@ -181,10 +182,10 @@ export default class SelectionEditor extends React.Component {
     const options = e.currentTarget.value;
     const { persistedState, localState, onChange } = this.props;
 
-    const optionsArray = options
+    const optionsArray = List(options
       .split('\n')
       .map(option => option.trim())
-      .filter(option => option && option.length);
+      .filter(option => option && option.length));
 
     const newLocalState = localState.set('options', options);
     const newPersistedState = persistedState.set('options', optionsArray);
@@ -198,7 +199,7 @@ export default class SelectionEditor extends React.Component {
 
   generateHTML(persistedState) {
     const { zone } = this.props;
-    const { label = '', options = [], isRequired = false,  marginTop, marginRight, marginBottom, marginLeft } = persistedState.toJS();
+    const { label = '', options = List(), isRequired = false,  marginTop, marginRight, marginBottom, marginLeft } = persistedState.toJS();
 
     const requiredAttr = {};
     if (isRequired) {


### PR DESCRIPTION
This pr makes two changes

1. Solves an issue where adding a second radio form would blow away the first. 
2. Fixes the styling of placeholder text in DraftJS so it is not on a separate line from the actual editor
![2017-12-12 13 15 17](https://user-images.githubusercontent.com/6528140/33901914-4cd8fc4c-df41-11e7-8306-227b09a5c070.gif)
