### PR TITLE
Fix: Cloudinary upload URL

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -248,9 +248,11 @@ export class Canvas extends React.Component {
     const { url, height, width } = imageDetails;
     const { canvasPosition } = this.props;
 
+    const urlWithoutProtocol = url.replace(/^https?\:\/\//i, "//");
+
     // Make sure the uploaded image does not have a larger size than the canvas
-    let heightOverride = (height > canvasPosition.get('height')) ? canvasPosition.get('height') : undefined;
-    let widthOverride = (width > canvasPosition.get('width')) ? canvasPosition.get('width') : undefined;
+    let heightOverride = (height > canvasPosition.get('height')) ? canvasPosition.get('height') : null;
+    let widthOverride = (width > canvasPosition.get('width')) ? canvasPosition.get('width') : null;
 
     const rowsToAdd = fromJS([
       {
@@ -260,7 +262,7 @@ export class Canvas extends React.Component {
             id: uuid(),
             type: 'Image',
             persistedState: {
-              url,
+              url: urlWithoutProtocol,
               width,
               height,
               heightOverride,

--- a/src/editors/image/ImageEditor.js
+++ b/src/editors/image/ImageEditor.js
@@ -126,7 +126,7 @@ export default class ImageEditor extends React.Component {
     }
     if (flowId) {
       linkAst.attrs['onclick'] = `window.parent.Appcues.show('${flowId}')`;
-      linkAst.attrs['data-step'] = BUTTON_ACTION_TYPES.NEXT_GROUP;
+      linkAst.attrs['data-step'] = BUTTON_ACTION_TYPES.END_STEP_AND_FLOW;
     }
 
     const ast = [


### PR DESCRIPTION
We were missing one case where a user drags and drops a file right onto the Full Add Component - the protocol wasn't being stripped. This fix will perform the stripping as with the other instances of image upload.

Also caught a couple of other things:
1. When an image fits inside the canvas, we were saving the height and width overrides as undefined, which is no bueno for firebase. Fixed by switching to null.
2. An old data-step value was still being used in Appcues triggers on images - we were using "end" instead of "end-flow" which fixes the brief flash of the following step when the current step is proceeded by another step group in the same flow.