### PR TITLE
hotfix: fix button styling and empty row content

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -352,10 +352,14 @@ export class Canvas extends React.Component {
       // Build the final HTML
       const rowsHtml = this.buildHtml(internalRows, internalZones);
 
-      // Rendering here with ReactDOMServer to convert the optional style object to CSS
-      const html = ReactDOMServer.renderToStaticMarkup(
-        <div className="canvas" style={style}>|ROWS|</div>
-      ).replace('|ROWS|', rowsHtml);
+      let html = '';
+
+      if (rowsHtml){
+        // Rendering here with ReactDOMServer to convert the optional style object to CSS
+        html = ReactDOMServer.renderToStaticMarkup(
+          <div className="canvas" style={style}>|ROWS|</div>
+        ).replace('|ROWS|', rowsHtml);
+      }
 
       const ast = HTMLParser.parse(html);
 

--- a/src/helpers/styles/editor.js
+++ b/src/helpers/styles/editor.js
@@ -44,7 +44,7 @@ export const selectMenuStyle = {
   cursor: 'pointer'
 };
 
-export const getButtonStyleString = (borderRadius=3, padding, fontSize, width) => {
+export const getButtonStyleString = (borderRadius, padding, fontSize, width) => {
 
   let buttonStyleString = 'text-align:center;';
 


### PR DESCRIPTION
right now if you delete all the rows in a tooltip or hotspot and refresh, we automatically insert a html component with <div class="canvas"></div>. to prevent this, we only pass back content if there are any actual rows. 