### PR TITLE
Remove click listeners on editor frame

### DIFF
--- a/src/components/AddButtonHorizRule.js
+++ b/src/components/AddButtonHorizRule.js
@@ -24,7 +24,6 @@ export default class AddButtonHorizRule extends React.Component {
     };
 
     this.handleAddNew = this.handleAddNew.bind(this);
-    this.onClick = this.onClick.bind(this);
   }
 
   componentDidMount() {
@@ -37,32 +36,12 @@ export default class AddButtonHorizRule extends React.Component {
     const { showEditorSelector } = this.state;
     this.setHasRoomToRenderOnRight();
 
-    const editor = document.getElementById('appcues-host');
-    const modalEditorFrame = document.getElementById('modal-editor-frame') ? document.getElementById('modal-editor-frame').contentDocument : null;
-    const didEditorSelectorClose = prevState.showEditorSelector && !showEditorSelector;
-    const didEditorSelectorOpen = !prevState.showEditorSelector && showEditorSelector;
-
-    if (didEditorSelectorOpen) {
-      modalEditorFrame && modalEditorFrame.addEventListener('click', this.onClick, true);
-      !modalEditorFrame && editor.addEventListener('click', this.onClick, true);
-    } else if (didEditorSelectorClose) {
-      modalEditorFrame && modalEditorFrame.removeEventListener('click', this.onClick, true);
-      !modalEditorFrame && editor.removeEventListener('click', this.onClick, true);
-    }
-
     if (shouldCloseMenu && showEditorSelector) {
       this.setState({ showEditorSelector: false });
       resetShouldCloseMenu();
       onEditorMenuClose();
     }
 
-  }
-
-  componentWillUnmount() {
-    const editor = document.getElementById('appcues-host');
-    const modalEditorFrame = document.getElementById('modalEditorFrame') ? document.getElementById('modal-editor-frame').contentDocument : null;
-    modalEditorFrame && modalEditorFrame.removeEventListener('click', this.onClick, true);
-    !modalEditorFrame && editor.removeEventListener('click', this.onClick, true);
   }
 
   render() {
@@ -132,14 +111,6 @@ export default class AddButtonHorizRule extends React.Component {
         </div>
       </div>
     );
-  }
-
-  onClick(e) {
-    e.preventDefault();
-    const { showEditorSelector, isHoveringOverAddButton } = this.state;
-    if (showEditorSelector && !isHoveringOverAddButton) {
-      this.setState({showEditorSelector: false});
-    }
   }
 
   handleAddNew() {


### PR DESCRIPTION
These click handlers were there to show/hide the editor selection menu,
but that's handled by clicks on the AddButtonContainer. The onClick
handler was also calling 'preventDefault()' on the events, which was
causing the browser to ignore the default behavior of clicks on the
file input, which is used to trigger the file manager. Since we don't
even need the click handlers attached to the frame, just remove them
since that will resolve the issue of the file manager not opening.

@acting326 is feature/iframe-crx the right branch to merging this into?