### PR TITLE
Fix for font color change on links

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "brace": "^0.11.0",
-    "draft-convert": "^2",
+    "draft-convert": "^2.1.1",
     "draft-js": "brandcast/draft-js-built#d6c2ffc",
     "emoji-mart": "^2.4.2",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/src/components/ColorPicker/EditableInput.js
+++ b/src/components/ColorPicker/EditableInput.js
@@ -13,13 +13,6 @@ export class EditableInput extends (PureComponent || Component) {
     };
   }
 
-  componentDidMount() {
-    const win = this.getWindow();
-    if(win) {
-      win.document.getElementById('hexInput').focus();
-    }
-  }
-
   componentWillReceiveProps(nextProps) {
     const input = this.input;
     if (nextProps.value !== this.state.value) {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -46,7 +46,8 @@ export class Toolbar extends React.Component {
       userProperties,
       shouldDisableXSS,
       sanitizeHtmlConfig,
-      numPages
+      numPages,
+      focusEditor
     } = this.props;
 
     const { hasRoomToRenderBelow } = this.state;
@@ -81,6 +82,7 @@ export class Toolbar extends React.Component {
             sanitizeHtmlConfig,
             shouldDisableXSS,
             hasRoomToRenderBelow,
+            focusEditor,
             ...(numPages && {numPages}),
             isActive: (selectedAction === editorAction.name),
             onToggleActive: (isActive) => {
@@ -108,7 +110,8 @@ Toolbar.propTypes = {
   userProperties: PropTypes.instanceOf(List).isRequired,
   selectedAction: PropTypes.string,
   sanitizeHtmlConfig: PropTypes.instanceOf(Map).isRequired,
-  shouldDisableXSS: PropTypes.bool.isRequired
+  shouldDisableXSS: PropTypes.bool.isRequired,
+  focusEditor: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {

--- a/src/components/Zone.js
+++ b/src/components/Zone.js
@@ -188,7 +188,11 @@ export class Zone extends React.Component {
       zonePosition: position,
       cloudinary,
       userProperties,
-      onChange: updateDraftWithChanges
+      onChange: updateDraftWithChanges,
+      focusEditor: () => {
+        const ed = this.activeEditor;
+        ed && ed.focus && ed.focus();
+      }
     };
 
     const inlineActionsProps = {

--- a/src/editor-actions/FontColor.js
+++ b/src/editor-actions/FontColor.js
@@ -81,17 +81,18 @@ export default class FontColor extends React.Component {
   }
 
   toggleDropdown() {
-    const { onToggleActive, isActive } = this.props;
+    const {onToggleActive, isActive, focusEditor} = this.props;
+
     this.setState({
       isMenuOpen: !this.state.isMenuOpen
     });
 
     if(isActive) {
+      focusEditor();
       setTimeout(() => onToggleActive(!isActive), 200);
     } else {
       onToggleActive(!isActive);
     }
-
   }
 
 
@@ -157,5 +158,6 @@ FontColor.propTypes = {
   onChange: PropTypes.func.isRequired,
   onToggleActive: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  hasRoomToRenderBelow: PropTypes.bool
+  hasRoomToRenderBelow: PropTypes.bool,
+  focusEditor: PropTypes.func.isRequired
 };

--- a/src/editor-actions/FontColor.js
+++ b/src/editor-actions/FontColor.js
@@ -129,16 +129,15 @@ export default class FontColor extends React.Component {
 
     nextEditorState = RichUtils.toggleInlineStyle(nextEditorState, CUSTOM_STYLE_PREFIX_COLOR + toggledColor);
 
-    const contentState = editorState.getCurrentContent();
-    const startKey = editorState.getSelection().getStartKey();
-    const startOffset = editorState.getSelection().getStartOffset();
-    const blockWithLinkAtBeginning = contentState.getBlockForKey(startKey);
+    let nextContentState = nextEditorState.getCurrentContent();
+    const startKey = nextEditorState.getSelection().getStartKey();
+    const startOffset = nextEditorState.getSelection().getStartOffset();
+    const blockWithLinkAtBeginning = nextContentState.getBlockForKey(startKey);
     const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
     if (linkKey) {
-      const linkInstance = contentState.getEntity(linkKey);
+      const linkInstance = nextContentState.getEntity(linkKey);
       if (linkInstance) {
-        const nextContentState = contentState.mergeEntityData(linkKey, { color: color.hex });
-
+        nextContentState = nextContentState.mergeEntityData(linkKey, { color: color.hex });
         nextEditorState = EditorState.push(nextEditorState, nextContentState, 'apply-inline-style');
       }
     }

--- a/src/editor-actions/Hyperlink.js
+++ b/src/editor-actions/Hyperlink.js
@@ -82,12 +82,14 @@ export default class Hyperlink extends React.Component {
   }
 
   toggleDropdown() {
-    const { onToggleActive, isActive } = this.props;
+    const { onToggleActive, isActive, focusEditor } = this.props;
+
     this.setState({
       isMenuOpen: !this.state.isMenuOpen
     });
 
     if(isActive) {
+      focusEditor();
       setTimeout(() => onToggleActive(!isActive), 200);
     } else {
       onToggleActive(!isActive);
@@ -128,5 +130,6 @@ Hyperlink.propTypes = {
   onToggleActive: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
   isUpdatingExistingLink: PropTypes.bool.isRequired,
-  hasRoomToRenderBelow: PropTypes.bool
+  hasRoomToRenderBelow: PropTypes.bool,
+  focusEditor: PropTypes.func.isRequired
 };

--- a/src/editor-actions/HyperlinkBlock.js
+++ b/src/editor-actions/HyperlinkBlock.js
@@ -7,7 +7,13 @@ import Hyperlink from './Hyperlink';
 export default class HyperlinkBlock extends React.Component {
 
   render() {
-    const { persistedState, isActive, onToggleActive, hasRoomToRenderBelow } = this.props;
+    const {
+      persistedState,
+      isActive,
+      onToggleActive,
+      hasRoomToRenderBelow,
+      focusEditor
+    } = this.props;
     const { href, isNewWindow } = persistedState.toJS();
 
     return (
@@ -18,6 +24,7 @@ export default class HyperlinkBlock extends React.Component {
         onToggleActive={ onToggleActive }
         hasRoomToRenderBelow={ hasRoomToRenderBelow }
         onChange={ (href, isNewWindow) => this.handleLink(href, isNewWindow) }
+        focusEditor={ focusEditor }
       />);
   }
 
@@ -43,5 +50,6 @@ HyperlinkBlock.propTypes = {
   onChange: PropTypes.func.isRequired,
   onToggleActive: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  hasRoomToRenderBelow: PropTypes.bool.isRequired
+  hasRoomToRenderBelow: PropTypes.bool.isRequired,
+  focusEditor: PropTypes.func.isRequired
 };

--- a/src/editor-actions/HyperlinkInline.js
+++ b/src/editor-actions/HyperlinkInline.js
@@ -35,7 +35,13 @@ class HyperlinkInline extends React.Component {
   }
 
   render() {
-    const { localState, isActive, onToggleActive, hasRoomToRenderBelow } = this.props;
+    const {
+      localState,
+      isActive,
+      onToggleActive,
+      hasRoomToRenderBelow,
+      focusEditor
+    } = this.props;
     const { linkKey } = this.state;
 
     let href = '';
@@ -66,6 +72,7 @@ class HyperlinkInline extends React.Component {
         hasRoomToRenderBelow={ hasRoomToRenderBelow }
         isUpdatingExistingLink={ isUpdatingExistingLink }
         onChange={ (href, isNewWindow) => this.handleLink(href, isNewWindow) }
+        focusEditor={ focusEditor }
       />);
   }
 
@@ -142,7 +149,8 @@ HyperlinkInline.propTypes = {
   onChange: PropTypes.func.isRequired,
   onToggleActive: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  hasRoomToRenderBelow: PropTypes.bool
+  hasRoomToRenderBelow: PropTypes.bool,
+  focusEditor: PropTypes.func.isRequired
 };
 
 HyperlinkInline.actionName = 'hyperlink-inline';

--- a/src/editor-actions/UserProperty.js
+++ b/src/editor-actions/UserProperty.js
@@ -126,12 +126,14 @@ export default class UserProperty extends React.Component {
   }
 
   toggleDropdown() {
-    const { onToggleActive, isActive } = this.props;
+    const { onToggleActive, isActive, focusEditor } = this.props;
+
     this.setState({
       isMenuOpen: !this.state.isMenuOpen
     });
 
     if(isActive) {
+      focusEditor();
       setTimeout(() => onToggleActive(!isActive), 200);
     } else {
       onToggleActive(!isActive);
@@ -184,6 +186,7 @@ UserProperty.propTypes = {
   onChange: PropTypes.func.isRequired,
   onToggleActive: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  userProperties: PropTypes.instanceOf(List).isRequired
+  userProperties: PropTypes.instanceOf(List).isRequired,
+  focusEditor: PropTypes.func.isRequired
 };
 

--- a/src/editors/richtext/RichTextToolbar.js
+++ b/src/editors/richtext/RichTextToolbar.js
@@ -54,8 +54,8 @@ const actions = [
     name: 'user-property'
   },
   {
-      Component: Margin,
-      name: 'margin'
+    Component: Margin,
+    name: 'margin'
   }
 ];
 

--- a/src/helpers/draft/LinkDecorator.js
+++ b/src/helpers/draft/LinkDecorator.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Entity } from 'draft-js';
 import Link from '../../components/entities/Link';
 
-function findLinkEntities(contentBlock, callback, contentState) {
+export function findLinkEntities(contentBlock, callback, contentState) {
   contentBlock.findEntityRanges(
     (character) => {
       const entityKey = character.getEntity();

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { convertToHTML as draftConvertToHTML, convertFromHTML as draftConvertFromHTML } from 'draft-convert';
 import { LinkDecorator, linkToEntity, entityToLink } from '../../helpers/draft/LinkDecorator';
-import { CompositeDecorator, ContentState, SelectionState } from 'draft-js';
+import { CompositeDecorator, ContentState } from 'draft-js';
 
 export const CUSTOM_STYLE_PREFIX_COLOR = 'COLOR_';
 export const NBSP = "\xA0";
@@ -25,7 +25,7 @@ export function convertFromHTML(htmlContent, convertOptions = {}) {
   // spaces in there, so just remove them here.
   htmlContent = htmlContent.replace(ZWSP_RE, "");
 
-  const contentState = draftConvertFromHTML({
+  return draftConvertFromHTML({
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (node instanceof HTMLElement && node.style) {
         currentStyle = currentStyle.withMutations(function(style) {
@@ -107,12 +107,6 @@ export function convertFromHTML(htmlContent, convertOptions = {}) {
     },
     ...convertOptions
   })(htmlContent);
-
-  const firstBlockKey = contentState.getFirstBlock().getKey();
-  return contentState.merge({
-    selectionBefore: SelectionState.createEmpty(firstBlockKey),
-    selectionAfter: SelectionState.createEmpty(firstBlockKey)
-  });
 }
 
 export function convertFromPastedHTML(htmlContent) {

--- a/src/helpers/draft/convert.js
+++ b/src/helpers/draft/convert.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { convertToHTML as draftConvertToHTML, convertFromHTML as draftConvertFromHTML } from 'draft-convert';
 import { LinkDecorator, linkToEntity, entityToLink } from '../../helpers/draft/LinkDecorator';
-import { CompositeDecorator, ContentState } from 'draft-js';
+import { CompositeDecorator, ContentState, SelectionState } from 'draft-js';
 
 export const CUSTOM_STYLE_PREFIX_COLOR = 'COLOR_';
 export const NBSP = "\xA0";
@@ -25,7 +25,7 @@ export function convertFromHTML(htmlContent, convertOptions = {}) {
   // spaces in there, so just remove them here.
   htmlContent = htmlContent.replace(ZWSP_RE, "");
 
-  return draftConvertFromHTML({
+  const contentState = draftConvertFromHTML({
     htmlToStyle: (nodeName, node, currentStyle) => {
       if (node instanceof HTMLElement && node.style) {
         currentStyle = currentStyle.withMutations(function(style) {
@@ -107,6 +107,12 @@ export function convertFromHTML(htmlContent, convertOptions = {}) {
     },
     ...convertOptions
   })(htmlContent);
+
+  const firstBlockKey = contentState.getFirstBlock().getKey();
+  return contentState.merge({
+    selectionBefore: SelectionState.createEmpty(firstBlockKey),
+    selectionAfter: SelectionState.createEmpty(firstBlockKey)
+  });
 }
 
 export function convertFromPastedHTML(htmlContent) {

--- a/src/helpers/draft/selection.js
+++ b/src/helpers/draft/selection.js
@@ -1,0 +1,12 @@
+export function getBlocksFromSelection(editorState) {
+  const selectionState = editorState.getSelection();
+  const currentContent = editorState.getCurrentContent();
+  const selectionStartKey = selectionState.getStartKey();
+  const selectionEndKey = currentContent.getKeyAfter(
+    selectionState.getEndKey()
+  );
+  return currentContent
+    .getBlockMap()
+    .skipUntil((val, key) => key === selectionStartKey)
+    .takeUntil((val, key) => key === selectionEndKey);
+}


### PR DESCRIPTION
Fixes
- [x] fix WYSIWYG blowing up when we try to change a link's font color
- [x] when changing the font color while over a link, we seem to revert to the previous selection
- [x] when opening the color picker it steals focus and removes the current text selection in the editor
- [x] fixes selection changing or being reset when font color is changed
- [x] restores focus and selection when popup menus are collapsed